### PR TITLE
array/object single argument display in stories

### DIFF
--- a/PHPUnit/Extensions/Story/Step.php
+++ b/PHPUnit/Extensions/Story/Step.php
@@ -108,7 +108,11 @@ abstract class PHPUnit_Extensions_Story_Step
                 break;
 
                 case 1: {
-                    return $this->arguments[0];
+                    $arguments = $this->arguments[0];
+                    if (!is_scalar($arguments)) {
+                        $arguments = var_export($arguments, TRUE);
+                    }
+                    return $arguments;
                 }
                 break;
 

--- a/Tests/StepTest.php
+++ b/Tests/StepTest.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once 'PHPUnit/Extensions/Story/TestCase.php';
+require_once 'PHPUnit/Extensions/Story/Then.php';
+
+class StepTest extends PHPUnit_Framework_TestCase {
+    protected function setUp() {
+        parent::setUp();
+    }
+
+    public function testGetArgumentsAsStringWithStringAsArgumentDisplayElementAsString() {
+        $Step = new PHPUnit_Extensions_Story_Then(array('action', 'keep behavior with string'));
+        $expected = "keep behavior with string";
+        $this->assertEquals($expected, $Step->getArguments(true));
+    }
+
+    public function testGetArgumentsAsStringWithSingleArrayAsArgumentDisplayElementAsString() {
+        $Step = new PHPUnit_Extensions_Story_Then(array('action', array('single element')));
+        $expected = "array (\n  0 => 'single element',\n)";
+        $this->assertEquals($expected, $Step->getArguments(true));
+    }
+
+    public function testGetArgumentsAsStringWithObjectAsArgumentDisplayElementAsString() {
+        $Step = new PHPUnit_Extensions_Story_Then(array('action', new PHPUnit_Extensions_Story_Then(array('action', array('single element')))));
+        $expected = "PHPUnit_Extensions_Story_Then::__set_state(array("
+            . "\n   'action' => 'action',"
+            . "\n   'arguments' => "
+            . "\n  array ("
+            . "\n    0 => "
+            . "\n    array ("
+            . "\n      0 => 'single element',"
+            . "\n    ),"
+            . "\n  ),"
+            . "\n))";
+        $this->assertEquals($expected, $Step->getArguments(true));
+    }
+}


### PR DESCRIPTION
Allows to display arguments in story tests cases with array/object single argument

When using when/then with an array as single argument after action, there was an error triggered.
